### PR TITLE
abstract-fix: Make Adafruit_SH110X not abstract

### DIFF
--- a/Adafruit_SH110X.cpp
+++ b/Adafruit_SH110X.cpp
@@ -303,3 +303,14 @@ void Adafruit_SH110X::display(void) {
   window_x2 = -1;
   window_y2 = -1;
 }
+
+// OVERRIDES ---------------------------------------------------------------
+
+/*!
+    @brief  Override for Print::write
+    @note   Override for Print::write so that Adafruit_SH110X is not an
+            abstract class.
+*/
+size_t Adafruit_SH110X::write(uint8_t c) { 
+  return Adafruit_GFX::write(c);
+}

--- a/Adafruit_SH110X.cpp
+++ b/Adafruit_SH110X.cpp
@@ -310,5 +310,7 @@ void Adafruit_SH110X::display(void) {
     @brief  Override for Print::write.
     @note   Override for Print::write so that Adafruit_SH110X is not an
             abstract class.
+    @return The output of the overriden Print::write(uint8_t) in
+            Adafruit_GFX (Adafruit_GFX::write(uint8_t)).
 */
 size_t Adafruit_SH110X::write(uint8_t c) { return Adafruit_GFX::write(c); }

--- a/Adafruit_SH110X.cpp
+++ b/Adafruit_SH110X.cpp
@@ -307,10 +307,8 @@ void Adafruit_SH110X::display(void) {
 // OVERRIDES ---------------------------------------------------------------
 
 /*!
-    @brief  Override for Print::write
+    @brief  Override for Print::write.
     @note   Override for Print::write so that Adafruit_SH110X is not an
             abstract class.
 */
-size_t Adafruit_SH110X::write(uint8_t c) { 
-  return Adafruit_GFX::write(c);
-}
+size_t Adafruit_SH110X::write(uint8_t c) { return Adafruit_GFX::write(c); }

--- a/Adafruit_SH110X.h
+++ b/Adafruit_SH110X.h
@@ -82,6 +82,7 @@ public:
 
   bool begin(uint8_t i2caddr = 0x3C, boolean reset = true);
   void display(void);
+  virtual size_t write(uint8_t);
 
 private:
 };


### PR DESCRIPTION
Added an override function for Print::write(uint8_t) in class Adafruit_SH110X so that the class is not abstract (in `Adafruit_SH110X.h` and `Adafruit_SH110X.cpp`).

Created Adafruit_SH110X::write(uint8_t) which simply returns the overridden write(uint8_t) from a base/parent class (`Adafruit_GFX`).

The changes have been tested on an `Adafruit 128x64 OLED FeatherWing`, running the example code from the following page on an `Adafruit Feather HUZZAH ESP8266`: https://learn.adafruit.com/adafruit-128x64-oled-featherwing/arduino-code.

Fixes #4 