### PR TITLE
Added option to disable startup splash per issue #13

### DIFF
--- a/Adafruit_SH1106G.cpp
+++ b/Adafruit_SH1106G.cpp
@@ -139,8 +139,10 @@ bool Adafruit_SH1106G::begin(uint8_t addr, bool reset) {
   _page_start_offset =
       2; // the SH1106 display we have found requires a small offset into memory
 
+#ifndef SH110X_NO_SPLASH
   drawBitmap((WIDTH - splash2_width) / 2, (HEIGHT - splash2_height) / 2,
              splash2_data, splash2_width, splash2_height, 1);
+#endif
 
   // Init sequence, make sure its under 32 bytes, or split into multiples!
   // clang-format off

--- a/Adafruit_SH1107.cpp
+++ b/Adafruit_SH1107.cpp
@@ -138,6 +138,7 @@ bool Adafruit_SH1107::begin(uint8_t addr, bool reset) {
 
   setContrast(0x2F);
 
+#ifndef SH110X_NO_SPLASH
   // the featherwing with 128x64 oled is 'rotated' so to make the splash right,
   // rotate!
   if (WIDTH == 64 && HEIGHT == 128) {
@@ -150,6 +151,7 @@ bool Adafruit_SH1107::begin(uint8_t addr, bool reset) {
     drawBitmap((HEIGHT - splash2_width) / 2, (WIDTH - splash2_height) / 2,
                splash2_data, splash2_width, splash2_height, 1);
   }
+#endif
 
   // Init sequence, make sure its under 32 bytes, or split into multiples!
   // clang-format off

--- a/Adafruit_SH110X.h
+++ b/Adafruit_SH110X.h
@@ -31,6 +31,9 @@
 #define SH110X_WHITE 1   ///< Draw 'on' pixels
 #define SH110X_INVERSE 2 ///< Invert pixels
 
+// Uncomment to disable Adafruit splash logo
+//#define SH110X_NO_SPLASH
+
 #define SH110X_MEMORYMODE 0x20          ///< See datasheet
 #define SH110X_COLUMNADDR 0x21          ///< See datasheet
 #define SH110X_PAGEADDR 0x22            ///< See datasheet


### PR DESCRIPTION
This PR resolves #13 by adding the option to define `SH110X_NO_SPLASH` to disable the startup splash image shown by both the `Adafruit_SH1106G::begin()` and `Adafruit_SH1107::begin()` method implementations (this was done using the exact same implementation found in the related [Adafruit SSD1306 library](https://github.com/adafruit/Adafruit_SSD1306)).

I am hard-pressed to imagine how these changes could cause any limitations or regressions in this library and have tested these changes using the provided examples and my own codebase without any issues. I won't go into any further details about the library code changes, as it should be exceptionally straightforward and easy to review the 6 lines of code this PR introduces ;-).

Please advise if there is anything I much change for this PR to be merged.