### PR TITLE
Fix broken reset logic if reset pin exceeds 127 due to int8 overflow

### DIFF
--- a/Adafruit_SH1106G.cpp
+++ b/Adafruit_SH1106G.cpp
@@ -41,7 +41,7 @@
             allocation is performed there!
 */
 Adafruit_SH1106G::Adafruit_SH1106G(uint16_t w, uint16_t h, TwoWire *twi,
-                                   int8_t rst_pin, uint32_t clkDuring,
+                                   int16_t rst_pin, uint32_t clkDuring,
                                    uint32_t clkAfter)
     : Adafruit_SH110X(w, h, twi, rst_pin, clkDuring, clkAfter) {}
 
@@ -71,9 +71,9 @@ Adafruit_SH1106G::Adafruit_SH1106G(uint16_t w, uint16_t h, TwoWire *twi,
     @note   Call the object's begin() function before use -- buffer
             allocation is performed there!
 */
-Adafruit_SH1106G::Adafruit_SH1106G(uint16_t w, uint16_t h, int8_t mosi_pin,
-                                   int8_t sclk_pin, int8_t dc_pin,
-                                   int8_t rst_pin, int8_t cs_pin)
+Adafruit_SH1106G::Adafruit_SH1106G(uint16_t w, uint16_t h, int16_t mosi_pin,
+                                   int16_t sclk_pin, int16_t dc_pin,
+                                   int16_t rst_pin, int16_t cs_pin)
     : Adafruit_SH110X(w, h, mosi_pin, sclk_pin, dc_pin, rst_pin, cs_pin) {}
 
 /*!
@@ -102,8 +102,8 @@ Adafruit_SH1106G::Adafruit_SH1106G(uint16_t w, uint16_t h, int8_t mosi_pin,
             allocation is performed there!
 */
 Adafruit_SH1106G::Adafruit_SH1106G(uint16_t w, uint16_t h, SPIClass *spi,
-                                   int8_t dc_pin, int8_t rst_pin, int8_t cs_pin,
-                                   uint32_t bitrate)
+                                   int16_t dc_pin, int16_t rst_pin,
+                                   int16_t cs_pin, uint32_t bitrate)
     : Adafruit_SH110X(w, h, spi, dc_pin, rst_pin, cs_pin, bitrate) {}
 
 /*!

--- a/Adafruit_SH1107.cpp
+++ b/Adafruit_SH1107.cpp
@@ -41,7 +41,7 @@
             allocation is performed there!
 */
 Adafruit_SH1107::Adafruit_SH1107(uint16_t w, uint16_t h, TwoWire *twi,
-                                 int8_t rst_pin, uint32_t clkDuring,
+                                 int16_t rst_pin, uint32_t clkDuring,
                                  uint32_t clkAfter)
     : Adafruit_SH110X(w, h, twi, rst_pin, clkDuring, clkAfter) {}
 
@@ -71,9 +71,9 @@ Adafruit_SH1107::Adafruit_SH1107(uint16_t w, uint16_t h, TwoWire *twi,
     @note   Call the object's begin() function before use -- buffer
             allocation is performed there!
 */
-Adafruit_SH1107::Adafruit_SH1107(uint16_t w, uint16_t h, int8_t mosi_pin,
-                                 int8_t sclk_pin, int8_t dc_pin, int8_t rst_pin,
-                                 int8_t cs_pin)
+Adafruit_SH1107::Adafruit_SH1107(uint16_t w, uint16_t h, int16_t mosi_pin,
+                                 int16_t sclk_pin, int16_t dc_pin,
+                                 int16_t rst_pin, int16_t cs_pin)
     : Adafruit_SH110X(w, h, mosi_pin, sclk_pin, dc_pin, rst_pin, cs_pin) {}
 
 /*!
@@ -102,8 +102,8 @@ Adafruit_SH1107::Adafruit_SH1107(uint16_t w, uint16_t h, int8_t mosi_pin,
             allocation is performed there!
 */
 Adafruit_SH1107::Adafruit_SH1107(uint16_t w, uint16_t h, SPIClass *spi,
-                                 int8_t dc_pin, int8_t rst_pin, int8_t cs_pin,
-                                 uint32_t bitrate)
+                                 int16_t dc_pin, int16_t rst_pin,
+                                 int16_t cs_pin, uint32_t bitrate)
     : Adafruit_SH110X(w, h, spi, dc_pin, rst_pin, cs_pin, bitrate) {}
 
 /*!

--- a/Adafruit_SH110X.cpp
+++ b/Adafruit_SH110X.cpp
@@ -74,7 +74,7 @@
             allocation is performed there!
 */
 Adafruit_SH110X::Adafruit_SH110X(uint16_t w, uint16_t h, TwoWire *twi,
-                                 int8_t rst_pin, uint32_t clkDuring,
+                                 int16_t rst_pin, uint32_t clkDuring,
                                  uint32_t clkAfter)
     : Adafruit_GrayOLED(1, w, h, twi, rst_pin, clkDuring, clkAfter) {}
 
@@ -104,9 +104,9 @@ Adafruit_SH110X::Adafruit_SH110X(uint16_t w, uint16_t h, TwoWire *twi,
     @note   Call the object's begin() function before use -- buffer
             allocation is performed there!
 */
-Adafruit_SH110X::Adafruit_SH110X(uint16_t w, uint16_t h, int8_t mosi_pin,
-                                 int8_t sclk_pin, int8_t dc_pin, int8_t rst_pin,
-                                 int8_t cs_pin)
+Adafruit_SH110X::Adafruit_SH110X(uint16_t w, uint16_t h, int16_t mosi_pin,
+                                 int16_t sclk_pin, int16_t dc_pin,
+                                 int16_t rst_pin, int16_t cs_pin)
     : Adafruit_GrayOLED(1, w, h, mosi_pin, sclk_pin, dc_pin, rst_pin, cs_pin) {}
 
 /*!
@@ -135,8 +135,8 @@ Adafruit_SH110X::Adafruit_SH110X(uint16_t w, uint16_t h, int8_t mosi_pin,
             allocation is performed there!
 */
 Adafruit_SH110X::Adafruit_SH110X(uint16_t w, uint16_t h, SPIClass *spi,
-                                 int8_t dc_pin, int8_t rst_pin, int8_t cs_pin,
-                                 uint32_t bitrate)
+                                 int16_t dc_pin, int16_t rst_pin,
+                                 int16_t cs_pin, uint32_t bitrate)
     : Adafruit_GrayOLED(1, w, h, spi, dc_pin, rst_pin, cs_pin, bitrate) {}
 
 /*!

--- a/Adafruit_SH110X.h
+++ b/Adafruit_SH110X.h
@@ -74,12 +74,13 @@ class Adafruit_SH110X : public Adafruit_GrayOLED {
 public:
   // NEW CONSTRUCTORS -- recommended for new projects
   Adafruit_SH110X(uint16_t w, uint16_t h, TwoWire *twi = &Wire,
-                  int8_t rst_pin = -1, uint32_t preclk = 400000,
+                  int16_t rst_pin = -1, uint32_t preclk = 400000,
                   uint32_t postclk = 100000);
-  Adafruit_SH110X(uint16_t w, uint16_t h, int8_t mosi_pin, int8_t sclk_pin,
-                  int8_t dc_pin, int8_t rst_pin, int8_t cs_pin);
-  Adafruit_SH110X(uint16_t w, uint16_t h, SPIClass *spi, int8_t dc_pin,
-                  int8_t rst_pin, int8_t cs_pin, uint32_t bitrate = 8000000UL);
+  Adafruit_SH110X(uint16_t w, uint16_t h, int16_t mosi_pin, int16_t sclk_pin,
+                  int16_t dc_pin, int16_t rst_pin, int16_t cs_pin);
+  Adafruit_SH110X(uint16_t w, uint16_t h, SPIClass *spi, int16_t dc_pin,
+                  int16_t rst_pin, int16_t cs_pin,
+                  uint32_t bitrate = 8000000UL);
 
   virtual ~Adafruit_SH110X(void) = 0;
 
@@ -100,12 +101,13 @@ private:
 class Adafruit_SH1106G : public Adafruit_SH110X {
 public:
   Adafruit_SH1106G(uint16_t w, uint16_t h, TwoWire *twi = &Wire,
-                   int8_t rst_pin = -1, uint32_t preclk = 400000,
+                   int16_t rst_pin = -1, uint32_t preclk = 400000,
                    uint32_t postclk = 100000);
-  Adafruit_SH1106G(uint16_t w, uint16_t h, int8_t mosi_pin, int8_t sclk_pin,
-                   int8_t dc_pin, int8_t rst_pin, int8_t cs_pin);
-  Adafruit_SH1106G(uint16_t w, uint16_t h, SPIClass *spi, int8_t dc_pin,
-                   int8_t rst_pin, int8_t cs_pin, uint32_t bitrate = 8000000UL);
+  Adafruit_SH1106G(uint16_t w, uint16_t h, int16_t mosi_pin, int16_t sclk_pin,
+                   int16_t dc_pin, int16_t rst_pin, int16_t cs_pin);
+  Adafruit_SH1106G(uint16_t w, uint16_t h, SPIClass *spi, int16_t dc_pin,
+                   int16_t rst_pin, int16_t cs_pin,
+                   uint32_t bitrate = 8000000UL);
 
   ~Adafruit_SH1106G(void);
 
@@ -119,12 +121,13 @@ public:
 class Adafruit_SH1107 : public Adafruit_SH110X {
 public:
   Adafruit_SH1107(uint16_t w, uint16_t h, TwoWire *twi = &Wire,
-                  int8_t rst_pin = -1, uint32_t preclk = 400000,
+                  int16_t rst_pin = -1, uint32_t preclk = 400000,
                   uint32_t postclk = 100000);
-  Adafruit_SH1107(uint16_t w, uint16_t h, int8_t mosi_pin, int8_t sclk_pin,
-                  int8_t dc_pin, int8_t rst_pin, int8_t cs_pin);
-  Adafruit_SH1107(uint16_t w, uint16_t h, SPIClass *spi, int8_t dc_pin,
-                  int8_t rst_pin, int8_t cs_pin, uint32_t bitrate = 8000000UL);
+  Adafruit_SH1107(uint16_t w, uint16_t h, int16_t mosi_pin, int16_t sclk_pin,
+                  int16_t dc_pin, int16_t rst_pin, int16_t cs_pin);
+  Adafruit_SH1107(uint16_t w, uint16_t h, SPIClass *spi, int16_t dc_pin,
+                  int16_t rst_pin, int16_t cs_pin,
+                  uint32_t bitrate = 8000000UL);
 
   ~Adafruit_SH1107(void);
 


### PR DESCRIPTION
When initializing a display like:

```cpp
display.begin(0, true);
```

And with a `rst_pin` number greater than 127 (like `0xC2` in my case) fails because the number overflows the largest int8_t number and wraps around to negative value which is interpreted as "not connected".

This is in conjunction with adafruit/Adafruit-GFX-Library#449