### PR TITLE
add ESP32S3 support for Featherwing OLED example

### DIFF
--- a/examples/OLED_featherwing/OLED_featherwing.ino
+++ b/examples/OLED_featherwing/OLED_featherwing.ino
@@ -29,7 +29,7 @@ Adafruit_SH1107 display = Adafruit_SH1107(64, 128, &Wire);
   #define BUTTON_A 31
   #define BUTTON_B 30
   #define BUTTON_C 27
-#else // 32u4, M0, M4, nrf52840, esp32-s2 and 328p
+#else // 32u4, M0, M4, nrf52840, esp32-s2, esp32-s3 and 328p
   #define BUTTON_A  9
   #define BUTTON_B  6
   #define BUTTON_C  5

--- a/examples/OLED_featherwing/OLED_featherwing.ino
+++ b/examples/OLED_featherwing/OLED_featherwing.ino
@@ -10,7 +10,10 @@ Adafruit_SH1107 display = Adafruit_SH1107(64, 128, &Wire);
   #define BUTTON_A  0
   #define BUTTON_B 16
   #define BUTTON_C  2
-#elif defined(ESP32) && !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2)
+#elif defined(ESP32) && \
+    !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S2) && \
+    !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3) && \
+    !defined(ARDUINO_ADAFRUIT_FEATHER_ESP32S3_NOPSRAM)
   #define BUTTON_A 15
   #define BUTTON_B 32
   #define BUTTON_C 14


### PR DESCRIPTION
Single line change so the Feather ESP32-S3 boards use the same button pin numbers as the ESP32-S2 for the [128x64 FeatherWing OLED](https://www.adafruit.com/product/4650).

[Adafruit Feather ESP32-S3](https://www.adafruit.com/product/5477)

[Adafruit Feather ESP32-S3-NOPSRAM](https://www.adafruit.com/product/5323)

Pointed out by [sgomes in the forums](https://forums.adafruit.com/viewtopic.php?t=215329).

builds and confirmed to work.