### PR TITLE
Clangify

### DIFF
--- a/Adafruit_SH110X.h
+++ b/Adafruit_SH110X.h
@@ -32,7 +32,7 @@
 #define SH110X_INVERSE 2 ///< Invert pixels
 
 // Uncomment to disable Adafruit splash logo
-//#define SH110X_NO_SPLASH
+// #define SH110X_NO_SPLASH
 
 #define SH110X_MEMORYMODE 0x20          ///< See datasheet
 #define SH110X_COLUMNADDR 0x21          ///< See datasheet


### PR DESCRIPTION
Fixes Clang-format error introduced by https://github.com/adafruit/Adafruit_SH110x/pull/26


```
Run python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
--- ./Adafruit_SH[11](https://github.com/adafruit/Adafruit_SH110x/actions/runs/13501086643/job/37719443266#step:7:12)0X.h	(original)
+++ ./Adafruit_SH110X.h	(reformatted)
@@ -32,7 +32,7 @@
 #define SH110X_INVERSE 2 ///< Invert pixels
 
 // Uncomment to disable Adafruit splash logo
-//#define SH110X_NO_SPLASH
+// #define SH110X_NO_SPLASH
 
 #define SH110X_MEMORYMODE 0x[20](https://github.com/adafruit/Adafruit_SH110x/actions/runs/13501086643/job/37719443266#step:7:21)          ///< See datasheet
 #define SH110X_COLUMNADDR 0x[21](https://github.com/adafruit/Adafruit_SH110x/actions/runs/13501086643/job/37719443266#step:7:22)          ///< See datasheet
```