### PR TITLE
Comment

### DIFF
--- a/examples/OLED_QTPY_SH1106/SH1106_128x64_i2c_QTPY/SH1106_128x64_i2c_QTPY.ino
+++ b/examples/OLED_QTPY_SH1106/SH1106_128x64_i2c_QTPY/SH1106_128x64_i2c_QTPY.ino
@@ -24,6 +24,7 @@
 
 /* Uncomment the initialize the I2C address , uncomment only one, If you get a totally blank screen try the other*/
 #define i2c_Address 0x3c //initialize with the I2C addr 0x3C Typically eBay OLED's
+                         // e.g. the one with GM12864-77 written on it
 //#define i2c_Address 0x3d //initialize with the I2C addr 0x3D Typically Adafruit OLED's
 
 #define SCREEN_WIDTH 128 // OLED display width, in pixels

--- a/examples/OLED_QTPY_SH1106/SH1106_128x64_i2c_QTPY/SH1106_128x64_i2c_QTPY.ino
+++ b/examples/OLED_QTPY_SH1106/SH1106_128x64_i2c_QTPY/SH1106_128x64_i2c_QTPY.ino
@@ -60,6 +60,17 @@ static const unsigned char PROGMEM logo16_glcd_bmp[] =
   B00000000, B00110000
 };
 
+void testdrawbitmap(const uint8_t *bitmap, uint8_t w, uint8_t h);
+void testdrawchar(void);
+void testdrawcircle(void);
+void testfillrect(void);
+void testdrawtriangle(void);
+void testfilltriangle(void);
+void testdrawroundrect(void);
+void testfillroundrect(void);
+void testdrawrect(void);
+void testdrawline();
+
 
 void setup()   {
 

--- a/examples/SH1107_128x128/SH1107_128x128.ino
+++ b/examples/SH1107_128x128/SH1107_128x128.ino
@@ -52,6 +52,21 @@ static const unsigned char PROGMEM logo_bmp[] =
   0b00000000, 0b00110000 };
 
 
+void testdrawline();
+void testdrawrect(void);
+void testfillrect(void);
+void testdrawcircle(void);
+void testfillcircle(void);
+void testdrawroundrect(void);
+void testfillroundrect(void);
+void testdrawtriangle(void);
+void testfilltriangle(void);
+void testdrawchar(void);
+void testdrawstyles(void);
+void testdrawbitmap(void);
+void testanimate(const uint8_t *bitmap, uint8_t w, uint8_t h);
+
+
 void setup()   {
 
   Serial.begin(9600);


### PR DESCRIPTION
- Scope of change: Just a) comment to be found by search engines, b) forward declarations

- Forward declarations are not necessary, but for me they were practical for use with my custom compile command line. Maybe not-so experienced Arduino developers don't like it. So I don't mind if you dismiss the change

- SH1106_128x64_i2c_QTPY.ino: compiled + uploaded + tested
- SH1107_128x128.ino: compiled + uploaded, but cannot test (no device)