### PR TITLE
Propagate GrayOLED initialization failures from begin

### DIFF
--- a/Adafruit_SH1106G.cpp
+++ b/Adafruit_SH1106G.cpp
@@ -134,7 +134,9 @@ Adafruit_SH1106G::~Adafruit_SH1106G(void) {}
 */
 bool Adafruit_SH1106G::begin(uint8_t addr, bool reset) {
 
-  Adafruit_GrayOLED::_init(addr, reset);
+  if (!Adafruit_GrayOLED::_init(addr, reset)) {
+    return false;
+  }
 
   _page_start_offset =
       2; // the SH1106 display we have found requires a small offset into memory

--- a/Adafruit_SH1107.cpp
+++ b/Adafruit_SH1107.cpp
@@ -134,7 +134,9 @@ Adafruit_SH1107::~Adafruit_SH1107(void) {}
 */
 bool Adafruit_SH1107::begin(uint8_t addr, bool reset) {
 
-  Adafruit_GrayOLED::_init(addr, reset);
+  if (!Adafruit_GrayOLED::_init(addr, reset)) {
+    return false;
+  }
 
   setContrast(0x2F);
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Adafruit SH110X
-version=2.1.14
+version=2.1.15
 author=Adafruit
 maintainer=Adafruit <info@adafruit.com>
 sentence=SH110X oled driver library for monochrome displays with SH1107 or SH1106G drivers


### PR DESCRIPTION
## Summary

Both `Adafruit_SH1106G::begin()` and `Adafruit_SH1107::begin()` document that they return `false` when allocation or initialization fails, but they ignored the return value from `Adafruit_GrayOLED::_init()` and continued issuing display setup commands.

Return immediately when the shared GrayOLED initialization fails. This matches the existing pattern in Adafruit's SSD1305 and SSD1327 libraries.

## Verification

- Compiled the two production `begin()` implementations with MinGW GCC 8.1.0 using `-Wall -Wextra -Werror`.
- With `_init()` forced to fail, both `begin()` methods return `false` and make no command-list or contrast calls.
- With `_init()` succeeding, both return `true`; the existing success path still makes three aggregate command-list calls and one contrast call.

## Limitations

The verification is a host-side control-flow test with mocked bus initialization. No physical SH1106G or SH1107 display was used.
